### PR TITLE
Rank in speech and examine handling

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -78,14 +78,16 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	return ""
 
 /atom/movable/proc/compose_job(atom/movable/speaker, message_langs, raw_message, radio_freq)
-	var/speakerJob = speaker.GetJob()
-	message_admins("[ speakerJob ? " (" +  speakerJob + ")" : ""]")
 	return ""
 
 //NSV13
 /atom/movable/proc/compose_rank(atom/movable/speaker)
+	if (!CONFIG_GET(flag/show_ranks))
+		return
+
 	var/job
 	var/rank = ""
+
 	if (istype(speaker, /mob/living/carbon/human))
 		var/mob/living/carbon/human/speakerMob = speaker
 		job = speakerMob.get_assignment()
@@ -226,7 +228,6 @@ INITIALIZE_IMMEDIATE(/atom/movable/virtualspeaker)
 		job = "Unknown"
 
 /atom/movable/virtualspeaker/GetJob()
-	message_admins("Virtual speaker job is [job]")
 	return job
 
 /atom/movable/virtualspeaker/GetSource()

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -71,13 +71,32 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	if(istype(D) && D.display_icon(src))
 		languageicon = "[D.get_icon()] "
 
-	return "[spanpart1][spanpart2][freqpart][languageicon][compose_track_href(speaker, namepart)][namepart][compose_job(speaker, message_language, raw_message, radio_freq)][endspanpart][messagepart]"
+	//NSV13 - added [compose_rank(speaker)]
+	return "[spanpart1][spanpart2][freqpart][languageicon][compose_track_href(speaker, namepart)][compose_rank(speaker)][namepart][compose_job(speaker, message_language, raw_message, radio_freq)][endspanpart][messagepart]"
 
 /atom/movable/proc/compose_track_href(atom/movable/speaker, message_langs, raw_message, radio_freq)
 	return ""
 
 /atom/movable/proc/compose_job(atom/movable/speaker, message_langs, raw_message, radio_freq)
+	var/speakerJob = speaker.GetJob()
+	message_admins("[ speakerJob ? " (" +  speakerJob + ")" : ""]")
 	return ""
+
+//NSV13
+/atom/movable/proc/compose_rank(atom/movable/speaker)
+	var/job
+	var/rank = ""
+	if (istype(speaker, /mob/living/carbon/human))
+		var/mob/living/carbon/human/speakerMob = speaker
+		job = speakerMob.get_assignment()
+	else if (istype(speaker, /atom/movable/virtualspeaker))
+		var/atom/movable/virtualspeaker/VS = speaker
+		job = VS.GetJob()
+
+	if (job)
+		rank = "[SSjob.GetJob(job).display_rank] "
+
+	return rank
 
 /atom/movable/proc/say_mod(input, message_mode)
 	var/ending = copytext(input, length(input))
@@ -207,6 +226,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/virtualspeaker)
 		job = "Unknown"
 
 /atom/movable/virtualspeaker/GetJob()
+	message_admins("Virtual speaker job is [job]")
 	return job
 
 /atom/movable/virtualspeaker/GetSource()

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -307,3 +307,7 @@
 	if(CONFIG_GET(flag/security_has_maint_access))
 		return list(ACCESS_MAINT_TUNNELS)
 	return list()
+
+//NSV13
+/datum/job/proc/get_rank()
+	return display_rank

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -75,8 +75,6 @@
 	if(!ishuman(H))
 		return
 	var/mob/living/carbon/human/human = H
-	if (CONFIG_GET(flag/show_ranks))
-		human.fully_replace_character_name(H.real_name, "[display_rank] [human.real_name]") //nsv13 - Visibly display player ranks with their names.
 	if(M.client && (M.client.prefs.equipped_gear && M.client.prefs.equipped_gear.len))
 		for(var/gear in M.client.prefs.equipped_gear)
 			var/datum/gear/G = GLOB.gear_datums[gear]

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -13,7 +13,17 @@
 		if(HAS_TRAIT(L, TRAIT_PROSOPAGNOSIA))
 			obscure_name = TRUE
 
-	. = list("<span class='info'>*---------*\nThis is <EM>[!obscure_name ? name : "Unknown"]</EM>!")
+	//NSV13 - compose name in parts so we can add rank
+	var/display_name = ""
+	if (obscure_name)
+		display_name = "Unknown"
+	else
+		if (CONFIG_GET(flag/show_ranks))
+			var/assignment = get_assignment()
+			if (assignment)
+				display_name+= "[SSjob.GetJob(assignment).display_rank] "
+		display_name += "[name]"
+	. = list("<span class='info'>*---------*\nThis is <EM>[display_name]</EM>!")
 
 	var/list/obscured = check_obscured_slots()
 	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Stops renaming everyone to display their rank (_job.dm) and instead does it in speech (say.dm) and examine (examine.dm)

## Why It's Good For The Game
Cleaner way of doing it, can stop driving Francium up the wall

## Changelog
:cl:
refactor: Moved rank display out of _job.dm and into say.dm and examine.dm
/:cl: